### PR TITLE
Simplified key matrix handling

### DIFF
--- a/8255.c
+++ b/8255.c
@@ -170,9 +170,11 @@ void wr8255(uint16_t addr, uint8_t data)
 
 uint8_t rd8255(uint16_t addr)
 {
-  static uint8_t idxloop=0;   // Allow multiple loops through the key matrix
-                              // if F9 selected for badly behaved m/c games
-                              // F9 toggles scantimes variable between 1 & 3
+  static uint8_t newkey[KBDROWS] = { 0xFF,0xFF,0xFF,0xFF,0xFF,
+                                     0xFF,0xFF,0xFF,0xFF,0xFF };
+  static uint8_t idxloop=0;        /* Allows some m/c code games to work */
+                                   /* by keeping the press from the key  */
+                                   /* matrix active for scantimes cycles */
   uint8_t idx,retval;
 
   switch (addr&0x0003) {      // addr is between 0xE000 and 0xE002
@@ -181,70 +183,24 @@ uint8_t rd8255(uint16_t addr)
            break;
     case 1:// Port B is keyboard input
            idx=portA&0x0F;
-           // 10 lines to strobe, so idx must be between 0 and 9
-           if (idx<10) {
+           // 10 lines (KBDROWS) to strobe, so idx must be between 0 and 9
+           if (idx < KBDROWS) {
 
-             /* Most programs need this route */
-             if (scantimes == 1) {
-
-               /* This is row 9 or 8, so send key and reset*/
-               if (idx >= 8) {
-               retval = processkey[idx];
-               processkey[idx] = 0xFF;
-               }
-
-               /* This is a shifted key, but we've already scanned past */
-               /* row 8, so send nothing and wait for next scan loop    */
-               if ((idx < 8) && ((processkey[8] == 0xFE) ||
-                                 (processkey[8] == 0xDF))) {
-                 retval=0xFF;
-               }
-
-               /* There's no shift to wait for, send key*/
-               if ((idx < 8) && (processkey[8] != 0xFE)
-                             && (processkey[8] != 0xDF)) {
-                 retval=processkey[idx];
-                 processkey[idx] = 0xFF;
-               }
-
+             /* If we're at the top of the scan and the last key was  */
+             /* scanned scantimes, then get next key event to process */
+             if ((idx == 9) && (idxloop >= scantimes)) {
+               memcpy(newkey,processkey,KBDROWS);
+               memset(processkey,0xFF,KBDROWS);
+               idxloop=0;
              }
 
-             /* Some badly behaved m/c games need 2 or 3 passes through */
-             /* the raw keyboard matrix - scantimes = 2 or 3 */
-             else {
+             /* Return the current row of the keyboard matrix */
+             retval=newkey[idx];
 
-               /* If we're part way through processing a key, increment */
-               /* the loop */
+             /* Increment the number of scans if on last row of matrix */
+             if (idx == 0) 
+               ++idxloop;
 
-               if (idxloop > 0) {
-                 ++idxloop;
-                 //SHOW("idx, idxloop are %d%  d\n",idx,idxloop);
-               }
-
-               /* Reset processkey array if we've been through it */
-               /* scantimes after a keypress was sensed           */
-
-               if (idxloop == (KBDROWS*scantimes+1)) {
-                 /* Full keyboard scan completed scantimes */
-	         memset(processkey,0xFF,KBDROWS);
-                 idxloop=0;
-               }
-
-               /* If this is the first active keyboard row */
-               /* found since the last keypress, set idxloop to 1 */
-
-               if ((processkey[idx] != 0xFF) && (idxloop==0)) {
-                 idxloop=1;
-                 //SHOW("idx starting point, idxloop are %d%  d\n",idx,idxloop);
-               }
-
-               /* Return the current keyscan row contents */
-
-               if (idxloop > 0) {
-                 retval=processkey[idx];
-                 //SHOW("retval is %02x\n",retval);
-               }
-             }
            }
            else {
              retval=0xFF;                // 0xFF always returned if idx > 9


### PR DESCRIPTION
Simplified key matrix handling by using an intermediary variable between the raw keyboard input and the keyboard scanning method used by the MZ-80K. Ensures keyboard scans always start on row 9 and that the data being scanned is always complete before being scanned.