### PR TITLE
Improve handling of shifted keys in standard build

### DIFF
--- a/8255.c
+++ b/8255.c
@@ -210,7 +210,19 @@ uint8_t rd8255(uint16_t addr)
              if (idxloop > 0)
                --idxloop;
 #else
-             retval=processkey[idx];
+             if (idx < 8) {
+               // Wait for next strobe if shift key pressed
+               if (processkey[8]==0xFE)
+                 retval=0xFF;
+               else
+                 retval=processkey[idx];
+             }
+             else {
+               retval=processkey[idx];
+               if ((idx == 8) && (processkey[8]==0xFE)) 
+                 // Shift key has been processed - clear it
+                 processkey[idx]=0xFF;
+             }
 #endif
            }
            else

--- a/keyboard.c
+++ b/keyboard.c
@@ -144,8 +144,8 @@ static void process_kbd_report(hid_keyboard_report_t const *report)
     mzhidmapkey(report->keycode[0],report->modifier);
   }
   else {
-    // We have a key up to pass to the MZ-80K
-    mzhidmapkey(0x00,0x00);
+    // We have a key up - clear processkey array
+    memset(processkey,0xFF,KBDROWS);
   }
 
   return;


### PR DESCRIPTION
Improves the handling of shifted keys for standard builds. Closes #42 