### PR TITLE
cwrite() checksum code corrected

### DIFF
--- a/cassette.c
+++ b/cassette.c
@@ -918,12 +918,9 @@ void __not_in_flash_func (cwrite) (uint8_t nextbit)
     else {
       hightime=get_absolute_time();
     }
-    /* Check to see if we're at the end of the checksum */
+    /* Check to see if we're at the end of the checksum - this code assumes it's correct(!) and carries on regardless */
     if (secbits==CHK_L) {
-      if (chkbits==(((checksum[0]<<8)&0xFF00)|checksum[1]))
-        ;
-      else
-        bodybytes=((header[19]<<8)&0xFF00)|header[18]; // Needed for state 8
+      bodybytes=((header[19]<<8)&0xFF00)|header[18]; // Needed for state 8
       cwstate=4;
       chkbits=0;
       secbits=0;


### PR DESCRIPTION
cwrite() checksum code corrected - was incorrect after the removal of the "SHOW" code for v3.0.0. It silently ignores any checksum errors found when writing a file. This shouldn't matter for .mzf as the write checksum should never be wrong ...