### PR TITLE
Tape data file implementation

### DIFF
--- a/8255.c
+++ b/8255.c
@@ -1,11 +1,11 @@
 /* Sharp MZ-80K, MZ-80A 8255 & MZ-700 implementation */
-/*     Tim Holyoake, August 2024 - November 2025     */
+/*      Tim Holyoake, August 2024 - August 2026      */
 
 #include "picomz.h"
 
 // 8255 address to port mapping for the MZ-80K/A/700
 // The ports are all 8 bits wide 
-// Note that the MZ-80K/A/700 only use the 8255 in mode 0,
+// Note that the MZ-80K/A/700 only uses the 8255 in mode 0,
 // so this simplifies the implementation somewhat.
 
 static uint8_t portA;           /* 0xE000 - port A */
@@ -14,17 +14,17 @@ uint8_t portC;                  /* 0xE002 - port C - provides two 4 bit ports */
                                 /* 0xE003 - Control port */
 
 uint8_t cmotor=0;               /* Cassette motor off (0) or on (1) */
-                                /* Toggled to 0 during MZ startup */
 uint8_t csense=1;               /* Cassette sense toggle */
-                                /* Toggled to 0 during MZ startup */
                                 /* Note - the emulator currently ties the */
                                 /* cmotor & csense signals together. A more */
-                                /* faithful version would have */
-                                /* separate buttons for a virtual cassette */
-                                /* deck, so motor and sense are not always */
-                                /* the same. */
+                                /* faithful version would mimic buttons for */
+                                /* a virtual cassette deck, so motor and */
+                                /* sense operate independently */
 uint8_t vblank=0;               /* /VBLANK signal */
-uint8_t vgate;                  /* /VGATE signal  - not used */
+uint8_t vgate;                  /* /VGATE signal  - not used. Means some */
+                                /* 'clever' uses in MZ games / demos will not */
+                                /* work, but I think this is preferable to */
+                                /* lots of screen flicker for most uses. */
 
 static uint32_t blinktime;      /* Timer for cursor blink - susbstitutes for */
                                 /* the 555/556 timers in actual MZ hardware */

--- a/8255.c
+++ b/8255.c
@@ -13,7 +13,7 @@ static uint8_t portA;           /* 0xE000 - port A */
 uint8_t portC;                  /* 0xE002 - port C - provides two 4 bit ports */
                                 /* 0xE003 - Control port */
 
-uint8_t cmotor=1;               /* Cassette motor off (0) or on (1) */
+uint8_t cmotor=0;               /* Cassette motor off (0) or on (1) */
                                 /* Toggled to 0 during MZ startup */
 uint8_t csense=1;               /* Cassette sense toggle */
                                 /* Toggled to 0 during MZ startup */
@@ -129,12 +129,13 @@ void wr8255(uint16_t addr, uint8_t data)
                      }
                      break;
              case 1: // Bit to write to cassette tape when
-                     // motor and sense are on
+                     // motor is on
                      if (setbit)
                        portC|=0x02;
                      else
                        portC&=0xFD;
-                     if (csense && cmotor)
+                     //if (csense && cmotor)
+                     if (cmotor)
                        cwrite(setbit);
                      break;
              case 2: // SML/CAP toggle on MZ-80K

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@
 
   string(APPEND CMAKE_EXE_LINKER_FLAGS "-Wl,--print-memory-usage")
 
-  if (PICO_SDK_VERSION_STRING VERSION_LESS "2.3.0")
-    message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.3.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
+  if (PICO_SDK_VERSION_STRING VERSION_LESS "2.2.0")
+    message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.2.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
   endif()
 
   pico_sdk_init()

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To find a file to load from the microSD card, use the F1 key to browse its conte
 
 ## Brief developer notes
 
-Pico MZ version 3.1.0 works with Pico SDK 2.3.0.
+Pico MZ version 3.1.0 works with Pico SDK 2.2.0. Pico SDK 2.3.0 is known **not** to work with PicoMZ at the current time.
 
 ### Release highlights
 
@@ -84,13 +84,13 @@ CMake (version 3.13 or later) and a gcc cross compiler.
    sudo apt install cmake
    sudo apt install gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 ```   
-The Pico MZ relies on the latest stable release of the Raspberry Pico SDK. This, along with
+The Pico MZ relies on release 2.2.0 of the Raspberry Pico SDK. This, along with
 the Pico Extras repository must be available on your computer if you wish to re-compile the emulator.
 
 Assuming that you are already in the subdirectory in which you wish to install the Pico SDK, Pico Extras 
 and Pico MZ repositories, issue the commands:
 ```
-   git clone --recursive https://github.com/raspberrypi/pico-sdk.git -b 2.3.0
+   git clone --recursive https://github.com/raspberrypi/pico-sdk.git -b 2.2.0
    git clone https://github.com/raspberrypi/pico-extras.git -b master
 ```   
 Then clone **either** the current release of the Pico MZ repository:
@@ -130,4 +130,4 @@ There should now be two (Pico) or one (Pico 2) .uf2 files in your build director
 
 [The Pico MZ](https://z80.timholyoake.uk/the-pico-mz-80k/)
 
-### This README was last updated on 19th August 2026.
+### This README was last updated on 28th August 2026.

--- a/cassette.c
+++ b/cassette.c
@@ -26,8 +26,9 @@
 //(L_L+S256_L+HDR_L+(HDR_L/8)+CHK_L+(CHK_L/8)+L_L+WSGAP_L+STM_L+L_L)*2 
 
 #define TCOUNTERMAX 999  // Maximum value of tapecounter - used in mzspinny()
-uint8_t crstate=0;       // Holds tape state for cread()
-uint8_t cwstate=0;       // Holds tape state for cwrite()
+uint8_t crstate=13;       // Holds tape state for cread()
+                          // Initialised to 13 so cassette motor resets on boot
+uint8_t cwstate=0;        // Holds tape state for cwrite()
 
 uint8_t header[TAPEHEADERSIZE]; // Tape headers are always 128 bytes
 uint8_t body[TAPEBODYMAXSIZE];  // Maximum storage is 68K - 69632 bytes
@@ -331,7 +332,6 @@ int16_t tapeloader(int16_t n)
   //Error on opening root directory if res is non-zero
   if (res) 
     return(-1);
-  
 
   // If we're passed a number less than 0, use 0 (first file).
   if (n < 0) 
@@ -367,22 +367,16 @@ int16_t tapeloader(int16_t n)
     return(-1);
   }
 
-  // Work out how many bytes to read from the header - stored in
-  // locations header[19] and header[18] (msb, lsb)
-  //bodybytes=((header[19]<<8)&0xFF00)|header[18];
-  //f_read(&fp,body,bodybytes,&bytesread);
-  //if (bytesread != bodybytes) {
-  //  f_close(&fp);
-  //  return(-1);
-  //}
-
-  // Original method above won't work if the MZ file type is a data file.
-  // (or, at least it wouldn't if we took any notice of the return status!)
-  // Instead, attempt to read the maximum file size TAPEBODYMAXSIZE and 
-  // ignore any error - bytesread will almost certainly always be smaller
-  // than the request. v3.1.0, August 2026.
+  // Attempt to read the maximum file size TAPEBODYMAXSIZE and ignore
+  // underflow errors - bytesread will invariably be smaller than the request.
+  // Updated for v3.1.0, August 2026.
   memset(body,0x00,TAPEBODYMAXSIZE);
   f_read(&fp,body,TAPEBODYMAXSIZE,&bytesread);
+  // Still throw an error if we've read more than the requested size
+  if (bytesread > TAPEBODYMAXSIZE) {
+    f_close(&fp);
+    return(-1);
+  }
 
   // Update the preloaded tape name in the emulator status area. Note
   // this is the name stored in the header, NOT the actual file name on
@@ -492,12 +486,11 @@ int16_t tapeloader(int16_t n)
 
   // We've read the tape successfully if we get here
   f_close(&fp);
-
   return(n);     /* Return the file number loaded - matches requested */
 }
 
 /* Write a new file to sd card 'tape'                             */
-void tapewriter(uint16_t bodyoff)
+void tapewriter(uint16_t blkno)
 {
   uint8_t sharpfilelen=0;
   uint8_t sdfilename[22];  // sdfilename needs 1 more char than
@@ -509,7 +502,7 @@ void tapewriter(uint16_t bodyoff)
   FRESULT res;
   FIL fp;
 
-  mzemustatus[10]=0x20+(uint8_t)bodyoff;
+  mzemustatus[10]=(uint8_t) 0x20+blkno;
 
   // Sharp tape file name is up to 17 characters stored in header[1]
   // to header[17]. If less than 17 characters, name ends with 0x0D
@@ -539,9 +532,9 @@ void tapewriter(uint16_t bodyoff)
   f_write(&fp, header, TAPEHEADERSIZE, &bw);
 
   // Write the tape body to the file - note that we need multiples of
-  // this value if we have a data file (size will be bodybytes*(bodyoff+1))
+  // this value if we have a data file (size will be bodybytes*(blkno+1))
   uint16_t bodybytes=((header[19]<<8)&0xFF00)|header[18];
-  for (i=0;i<(bodybytes*(bodyoff+1));i++)
+  for (i=0;i<(bodybytes*(blkno+1));i++)
     f_write(&fp, &body[i], 1, &bw);
 
   // Close the file and return
@@ -561,7 +554,7 @@ void reset_tape(void)
   /* Also reset the motor and sense flags - not sure if this
      is really needed, but should be harmless ... */
   cmotor=0;
-  csense=0;
+  csense=1;
 
   return;
 }
@@ -588,32 +581,36 @@ uint8_t cread(void)
   static uint32_t secbits;   // Tracks where we are in the current tape section
 
   /* Below added for data file handling in version 3.1.0 */
-  static bool bsd3file;      // Set true in state 3 if file is a 0x03 data file
-  static bool bsd4file;      // Set true in state 3 if file is a 0x04 data file
-  static bool endofdatafile; // Set false in state 3 - set true when EOF marker
+  static bool bsd3file=false;// Set true in state 3 if file is a 0x03 data file
+  static bool bsd4file=false;// Set true in state 3 if file is a 0x04 data file
+  static bool endofdatafile=false; 
+                             // Set false in state 3 - set true when EOF marker
                              // seen in body processing (state 8) and bsd<x>file
                              // is true
-  static bool skip101112;    // Used to determine if we need to skip a copy
-                             // of the data block just read - multi-block data
-                             // files only
   static uint16_t bodyoff=0; // Body array offest - incremented by 1 per block
                              // if the file is a multi-block data file
-                             // Initialised to zero in state 3
   
 
-  if (cmotor==0) {
-    if (crstate==0) {
-      return(LONGPULSE); // Motor is off and we're not reading a tape
-    }
-    else {               // Motor is off and we've part read a tape
-      hilo=0;            // Reset hilo counter for next time motor is on
-      return(LONGPULSE);
-    }
+  // Deal with the motor off/on pause between data file blocks
+  // bodyoff is only non-zero if we're reading a multi-block data file
+  if ((cmotor==0) && (bodyoff>0) && (!endofdatafile)) {
+    mzemustatus[23]=0x20+bodyoff;
+    mzemustatus[24]=0x20+bodyoff;
+    mzemustatus[25]=0x20+crstate;
+    csense=0;
+    cmotor=1;
+    hilo=0;              // Reset hilo counter for next time motor is on
+    return(LONGPULSE);
+  }
+  else if (cmotor==0) {  // Motor is off and it's not a multi-block file
+    mzemustatus[21]=0x20+bodyoff;
+    hilo=0;              // Reset hilo counter for next time motor is on
+    return(LONGPULSE);
   }
 
-  // If we reach here, the motor is running and sense has been triggered
+  // If we reach here, the motor is running
   // but check that we're not writing a tape before doing anything ...
-  if (cwstate > 0) return(LONGPULSE);
+  if (cwstate>0) return(LONGPULSE);
 
   // To mimic a tape being read, we need to surround each bit sent with a
   // high bit and a low bit. The lines below do this in the simplest way
@@ -702,24 +699,22 @@ uint8_t cread(void)
       return(SHORTPULSE);
     }
 
-    /* Tape body - length is calculated from the values stored by the header */
-    /* in memory locations 0x1103 and 0x1102 from the 20th & 19th values     */
-    /* found in the header - i.e. header[19] (msb) and header[18] (lsb).     */
-    /* Note: This is the blocksize if we have an MZ-80A or MZ-80K tape,      */
-    /* not the total file length */
+    // Tape body length is calculated from the values stored by the header
+    // in memory locations 0x1103 and 0x1102 from the 20th & 19th values
+    // found in the header - i.e. header[19] (msb) and header[18] (lsb).
+    // Note: This is the blocksize if we have an MZ-80A or MZ-80K tape,
+    // not the total file length. On a MZ-700 a bug in the monitor means it
+    // may not be written correctly, so always force MZ-700 BSD files to 258
+    // bytes.
     bodybytes=((header[19]<<8)&0xFF00)|header[18];
     if (((mzmodel==MZ80K)||(mzmodel==MZ80A))&&(header[0]==0x03)) {
       bsd3file=true;
       endofdatafile=false;
-      // If we have a multi-block data file we need to skip each body copy
-      skip101112=true;
     }
     if ((mzmodel==MZ700)&&(header[0]==0x04)) {
       bodybytes=258;   // May not be set in the header, so force to 258 bytes.
       bsd4file=true;
       endofdatafile=false;
-      // If we have a multi-block data file we need to skip each body copy
-      skip101112=true;
     }
 
     /* At the end of the checksum */
@@ -767,14 +762,10 @@ uint8_t cread(void)
     longsent=false;
     crstate=8;
     mzemustatus[36]=0x27;
-    if (!cmotor) cmotor=1;
-    if (!csense) csense=1;
   }
 
   /* Process the tape body - state 8 */
   if (crstate==8) {
-    if (!cmotor) cmotor=1;
-    if (!csense) csense=1;
     if (secbits<(bodybytes*8)) {     // 1 byte = 8 bits to transmit
       /* One LONGPULSE is sent before every byte of the body */
       if (((secbits%8)==0) && (!longsent)) {
@@ -785,10 +776,13 @@ uint8_t cread(void)
         mzemustatus[20]=0x20+bodyoff;
         mzemustatus[21]=0x9a;
         /* If this is an MZ-80A or MZ-80K data file, check if we have 0xFF */
+        /* This indicates EOF and may appear anywhere in a block. MZ-700   */
+        /* data files are handled differently as they have a block number  */
+        /* in the first two bytes of each block. 0xFF, 0xFF indicates EOF  */
+        /* is in that block */
         if (((mzmodel==MZ80K)||(mzmodel==MZ80A)) && bsd3file) {
           if (body[(secbits/8)+(bodyoff*bodybytes)] == 0xFF) {
             endofdatafile=true;
-            skip101112=true;
             mzemustatus[30]=0x9A;
           }
           else {
@@ -805,6 +799,12 @@ uint8_t cread(void)
         return(LONGPULSE);
       }
       return(SHORTPULSE);
+    }
+    /* Check if we have processed the last block of a MZ-700 data file */
+    if (bsd4file && (body[0+(bodyoff*bodybytes)]==0xFF) 
+                 && (body[1+(bodyoff*bodybytes)]==0xFF)) { 
+      endofdatafile=true;
+      mzemustatus[6]=0x44;
     }
     /* At the end of the body, move onto checksum state (9) */
     mzemustatus[38]=0x28;
@@ -843,17 +843,14 @@ uint8_t cread(void)
     /* all of it */
     /* Assumes copy of program / data is never needed as .mzf files used */
     secbits=0;
+    // If we're not at the end of a data file, loop back for the next block
     if ((bsd3file||bsd4file) && (!endofdatafile)) {
-        secbits=0;
-        chkbits=0;
-        longsent=false;
         bodyoff++;
-        crstate=7;
+        crstate=10;
     }
     else {
       // End of file
       mzemustatus[39]=0x29;
-      secbits=0;
       crstate=13; 
     }
   }
@@ -872,29 +869,37 @@ uint8_t cread(void)
       return(LONGPULSE);
     }
     if (secbits<L_L+S256_L) {
+      mzemustatus[(40+(secbits-1))%8]=0x29+(secbits-1)/8;
       ++secbits;
+      if (secbits == L_L+S256_L) {
+        secbits=0;
+        crstate=7;
+        //memset(mzemustatus,0x00,200);
+        mzemustatus[32]=0x24;
+      }
       return(SHORTPULSE);
     }
-    secbits=0;
-    chkbits=0;
-    longsent=false;
-    ++bodyoff;
-    crstate=7;
-    memset(mzemustatus,0x00,200);
-    mzemustatus[30]=0x24;
   }
 
   if (crstate==13) {
   /* At end of body checksum, reset tape state, send final stop bit */
       mzemustatus[38]=0x9A;
       hilo=0;
+      bodyoff=0;
+      bsd3file=false;
+      bsd4file=false;
+      endofdatafile=false;
       reset_tape();
       return(LONGPULSE);
   }
 
   /* Catch any errors - shouldn't happen, but ...        */
-  /* Reset hilo to 0, reset state */
+  mzemustatus[198]=0x20+crstate;
   hilo=0;
+  bodyoff=0;
+  bsd3file=false;
+  bsd4file=false;
+  endofdatafile=false;
   reset_tape();
 
   return(LONGPULSE);
@@ -928,9 +933,8 @@ void cwrite(uint8_t nextbit)
   static uint16_t blocksize; // Set to file body size in state 2 if we have 
                              // a data file of any type (0x03 on MZ-80 or 
                              // 0x04 on MZ-700), otherwise zero
-  static uint16_t bodyoff;   // Body array offest - incremented by 1 per block
+  static uint16_t bodyoff=0; // Body array offest - incremented by 1 per block
                              // if the file is a multi-block data file
-                             // Initialised to zero in state 2
   
   if (cwstate==0) {
     /* The first high bit has been received */
@@ -1015,24 +1019,22 @@ void cwrite(uint8_t nextbit)
       bsd3file=false;
       bsd4file=false;
       endofdatafile=false;
-      blocksize=0;
-      bodyoff=0;
+      blocksize=((header[19]<<8)&0xFF00)|header[18];
       /* Is this a data file ? Type is 0x03 for MZ-80, 0x04 for MZ-700 */
-      if ((mzmodel == MZ80K) || (mzmodel == MZ80A)) {
-        if (header[0]==0x03) {
-          bsd3file=true;
-          blocksize=((header[19]<<8)&0xFF00)|header[18];
-          mzemustatus[0]=0x22;
-          mzemustatus[1]=0x99;
-        }
+      if (((mzmodel==MZ80K) || (mzmodel==MZ80A)) && (header[0]==0x03)) {
+        bsd3file=true;
+        // Blocksize is (usually!!) 0x0080 on a MZ-80K (128 bytes), 
+        // 0x0100 (256 bytes) on a MZ-80A
+        mzemustatus[0]=0x22;
+        mzemustatus[1]=0x99;
       }
-      else if (mzmodel == MZ700) {
-        if (header[0]==0x04) {
-          bsd4file=true;
-          blocksize=((header[19]<<8)&0xFF00)|header[18];
-          mzemustatus[0]=0x22;
-          mzemustatus[1]=0x9A;
-        }
+      else if ((mzmodel==MZ700) && (header[0]==0x04)) {
+        bsd4file=true;
+        // Force blocksize to 258 as the header may be faulty due to
+        // a MZ-700 monitor bug
+        blocksize=258;
+        mzemustatus[0]=0x24;
+        mzemustatus[1]=0x9A;
       }
     }
     return;
@@ -1065,6 +1067,7 @@ void cwrite(uint8_t nextbit)
     /* Check to see if we're at the end of the checksum - this code assumes it's correct(!) and carries on regardless */
     if (secbits==CHK_L) {
       bodybytes=((header[19]<<8)&0xFF00)|header[18]; // Needed for state 8
+      if (bsd3file || bsd4file) bodybytes=blocksize; // Overwrite if data file
       cwstate=4;
       chkbits=0;
       secbits=0;
@@ -1132,7 +1135,9 @@ void cwrite(uint8_t nextbit)
         // byte, we've seen the end of file marker. Note that the rest of
         // the block needs to be written, but the contents will be invalid.
         if (((secbits%8)==7) && (bsd3file))
-          if (body[(secbits/8)+(bodyoff*blocksize)]==0xFF) endofdatafile=true;
+          // 0xFF is NOT an EOF marker in type 0x04 data files
+          if (bsd3file && (body[(secbits/8)+(bodyoff*blocksize)]==0xFF))
+            endofdatafile=true;
         ++secbits;         // Increment data pulses counted
       }
     }
@@ -1142,11 +1147,14 @@ void cwrite(uint8_t nextbit)
     /* Check to see if we're at the end of the body or 0x04 data block */
     if (secbits==bodybytes*8) {
       if (bsd4file) {
+        mzemustatus[18]=0x24;
         if ((body[0+(bodyoff*blocksize)] == 0xFF) && 
             (body[1+(bodyoff*blocksize)] == 0xFF)) {
           /* We have the end of file marker for type 0x04 */
+          mzemustatus[19]=0x25;
           endofdatafile=true;
         }
+        mzemustatus[20]=0x26;
       }
       /* Need to increment bodyoff if we're not at end of a data file */
       if ((bsd3file||bsd4file)&&(!endofdatafile)) ++bodyoff;
@@ -1207,8 +1215,10 @@ void cwrite(uint8_t nextbit)
       // Assumed all ok - move onto the final state (13) or back to state 7
       // if we are processing a data file and it is multi-block. Note that
       // blocksize and bodybytes are the same for type 0x03 and 0x04 files ...
-      if (((bsd3file)||(bsd4file)) && (!endofdatafile)) 
+      if ((bsd3file||bsd4file) && (!endofdatafile)) {
+        mzemustatus[8]=0x20+bodyoff;
         cwstate=7;
+      }
       else
         cwstate=13;
       secbits=0;
@@ -1239,7 +1249,7 @@ void cwrite(uint8_t nextbit)
         secbits=0;
         high=0;
         low=0;
-        mzemustatus[2]=0x9B;
+        mzemustatus[3]=0x90;
       }
       else {
         // Error - quit now
@@ -1247,7 +1257,7 @@ void cwrite(uint8_t nextbit)
         secbits=0;
         high=0;
         low=0;
-        mzemustatus[2]=0xAA;
+        mzemustatus[3]=0x95;
       }
     }
     return;

--- a/cassette.c
+++ b/cassette.c
@@ -84,7 +84,7 @@ void mzspinny(uint8_t state)
   // Increment ignore. If this is >= counterinc then increment spinny.
   // If spinny > TCOUNTERMAX then spinny is reset to zero.
 
-  counterinc = (mzmodel == MZ700) ? 354 : 200;
+  counterinc = (mzmodel == MZ700) ? 708 : 400;
 
   if ((++ignore) >= counterinc) {
     ignore=0;
@@ -502,8 +502,6 @@ void tapewriter(uint16_t blkno)
   FRESULT res;
   FIL fp;
 
-  mzemustatus[10]=(uint8_t) 0x20+blkno;
-
   // Sharp tape file name is up to 17 characters stored in header[1]
   // to header[17]. If less than 17 characters, name ends with 0x0D
 
@@ -594,16 +592,12 @@ uint8_t cread(void)
   // Deal with the motor off/on pause between data file blocks
   // bodyoff is only non-zero if we're reading a multi-block data file
   if ((cmotor==0) && (bodyoff>0) && (!endofdatafile)) {
-    mzemustatus[23]=0x20+bodyoff;
-    mzemustatus[24]=0x20+bodyoff;
-    mzemustatus[25]=0x20+crstate;
     csense=0;
     cmotor=1;
     hilo=0;              // Reset hilo counter for next time motor is on
     return(LONGPULSE);
   }
   else if (cmotor==0) {  // Motor is off and it's not a multi-block file
-    mzemustatus[21]=0x20+bodyoff;
     hilo=0;              // Reset hilo counter for next time motor is on
     return(LONGPULSE);
   }
@@ -625,13 +619,16 @@ uint8_t cread(void)
     chkbits=0;
     longsent=false;
     crstate=1;
-    // We don't return here - always fall through to state 1 immediately
+    // We don't return from here - always fall through to state 1 immediately
   }
  
   /* Header preamble - bgap, btm, l - state 1 */
   // Note - 22,000 pulses in a real bgap, but anything > 100 will work
   // when a tape is being read (writing is different!) 
   if (crstate==1) {
+    // Update tape counter
+    if ((secbits%8)==0) 
+      mzspinny(1);
     if (secbits<RBGAP_L) {
       ++secbits;
       return(SHORTPULSE);
@@ -651,6 +648,9 @@ uint8_t cread(void)
 
   /* First copy of the header */
   if (crstate==2) {
+    // Update tape counter
+    if ((secbits%8)==0) 
+      mzspinny(1);
     if (secbits<HDR_L) {
       /* One LONGPULSE is sent before every byte of the header */
       if (((secbits%8)==0) && (longsent==false)) {
@@ -674,6 +674,9 @@ uint8_t cread(void)
 
   /* Header checksum - state 3 */
   if (crstate==3) {
+    // Update tape counter
+    if ((secbits%8)==0) 
+      mzspinny(1);
     if (secbits<CHK_L) {
       if ((secbits==0)&&(chkbits>0)) {
         // Need to calculate the header checksum
@@ -737,6 +740,9 @@ uint8_t cread(void)
   /* before we finally get to the tape body */
 
   if (crstate==7) {
+    // Update tape counter
+    if ((secbits%8)==0) 
+      mzspinny(1);
     if (secbits<L_L) {
       ++secbits;
       return(LONGPULSE);
@@ -761,20 +767,18 @@ uint8_t cread(void)
     chkbits=0;
     longsent=false;
     crstate=8;
-    mzemustatus[36]=0x27;
   }
 
   /* Process the tape body - state 8 */
   if (crstate==8) {
+    // Update tape counter
+    if ((secbits%8)==0) 
+      mzspinny(1);
     if (secbits<(bodybytes*8)) {     // 1 byte = 8 bits to transmit
       /* One LONGPULSE is sent before every byte of the body */
       if (((secbits%8)==0) && (!longsent)) {
         /* Note - we don't increment secbits here */
         longsent=true;
-        mzspinny(1); // Increment tape counter
-        mzemustatus[19]=0x9a;
-        mzemustatus[20]=0x20+bodyoff;
-        mzemustatus[21]=0x9a;
         /* If this is an MZ-80A or MZ-80K data file, check if we have 0xFF */
         /* This indicates EOF and may appear anywhere in a block. MZ-700   */
         /* data files are handled differently as they have a block number  */
@@ -783,10 +787,6 @@ uint8_t cread(void)
         if (((mzmodel==MZ80K)||(mzmodel==MZ80A)) && bsd3file) {
           if (body[(secbits/8)+(bodyoff*bodybytes)] == 0xFF) {
             endofdatafile=true;
-            mzemustatus[30]=0x9A;
-          }
-          else {
-            mzemustatus[40+(secbits/8)]=0x20+bodyoff;
           }
         }
         return(LONGPULSE);
@@ -804,16 +804,17 @@ uint8_t cread(void)
     if (bsd4file && (body[0+(bodyoff*bodybytes)]==0xFF) 
                  && (body[1+(bodyoff*bodybytes)]==0xFF)) { 
       endofdatafile=true;
-      mzemustatus[6]=0x44;
     }
     /* At the end of the body, move onto checksum state (9) */
-    mzemustatus[38]=0x28;
     secbits=0;
     crstate=9;
   }
 
   /* Body checksum - state 9 */
   if (crstate==9) {
+    // Update tape counter
+    if ((secbits%8)==0) 
+      mzspinny(1);
     if (secbits<CHK_L) {
       if ((secbits==0)&&(chkbits>0)) {
         // Need to calculate the body checksum
@@ -850,7 +851,6 @@ uint8_t cread(void)
     }
     else {
       // End of file
-      mzemustatus[39]=0x29;
       crstate=13; 
     }
   }
@@ -864,18 +864,18 @@ uint8_t cread(void)
   /* State 12 - a copy of the body checksum */
   
   if (crstate==10) {
+    // Update tape counter
+    if ((secbits%8)==0) 
+      mzspinny(1);
     if (secbits<L_L) {
       ++secbits;
       return(LONGPULSE);
     }
     if (secbits<L_L+S256_L) {
-      mzemustatus[(40+(secbits-1))%8]=0x29+(secbits-1)/8;
       ++secbits;
       if (secbits == L_L+S256_L) {
         secbits=0;
         crstate=7;
-        //memset(mzemustatus,0x00,200);
-        mzemustatus[32]=0x24;
       }
       return(SHORTPULSE);
     }
@@ -883,7 +883,6 @@ uint8_t cread(void)
 
   if (crstate==13) {
   /* At end of body checksum, reset tape state, send final stop bit */
-      mzemustatus[38]=0x9A;
       hilo=0;
       bodyoff=0;
       bsd3file=false;
@@ -894,7 +893,6 @@ uint8_t cread(void)
   }
 
   /* Catch any errors - shouldn't happen, but ...        */
-  mzemustatus[198]=0x20+crstate;
   hilo=0;
   bodyoff=0;
   bsd3file=false;
@@ -955,6 +953,9 @@ void cwrite(uint8_t nextbit)
 
   /* State 1 - tape header preamble */
   if (cwstate==1) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     if (nextbit==0) {
       lowtime=get_absolute_time();
       if (absolute_time_diff_us(hightime,lowtime) < READPT)
@@ -986,6 +987,9 @@ void cwrite(uint8_t nextbit)
 
   /* State 2 - header */
   if (cwstate==2) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     if (nextbit==0) {
       lowtime=get_absolute_time();
       if (absolute_time_diff_us(hightime,lowtime) < READPT)
@@ -1025,16 +1029,12 @@ void cwrite(uint8_t nextbit)
         bsd3file=true;
         // Blocksize is (usually!!) 0x0080 on a MZ-80K (128 bytes), 
         // 0x0100 (256 bytes) on a MZ-80A
-        mzemustatus[0]=0x22;
-        mzemustatus[1]=0x99;
       }
       else if ((mzmodel==MZ700) && (header[0]==0x04)) {
         bsd4file=true;
         // Force blocksize to 258 as the header may be faulty due to
         // a MZ-700 monitor bug
         blocksize=258;
-        mzemustatus[0]=0x24;
-        mzemustatus[1]=0x9A;
       }
     }
     return;
@@ -1042,6 +1042,9 @@ void cwrite(uint8_t nextbit)
 
   /* State 3 - header checksum */
   if (cwstate==3) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     if (nextbit==0) {
       lowtime=get_absolute_time();
       if (absolute_time_diff_us(hightime,lowtime) < READPT)
@@ -1086,6 +1089,9 @@ void cwrite(uint8_t nextbit)
   /* State 7 - long pulse, 11,000 short, 20 long, 20 short, long pulse */
 
   if (cwstate==4) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     ++secbits;                   // Increment number of bits received
                                  // (1 pulse = 1 followed by 0 = 2 bits)
     if (secbits==SKIP_L) {
@@ -1099,6 +1105,9 @@ void cwrite(uint8_t nextbit)
   /* State 7 - long pulse, short tape gap, short tape mark */
   /* Only used in emulator for multi-block data files of type 0x03 or 0x04 */
   if (cwstate==7) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     ++secbits;                   // Increment number of bits received
                                  // (1 pulse = 1 followed by 0 = 2 bits)
     if (secbits==((L_L+WSGAP_L+STM_L+L_L)*2)) {
@@ -1110,6 +1119,9 @@ void cwrite(uint8_t nextbit)
 
   /* State 8 - file body */
   if (cwstate==8) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     if (nextbit==0) {
       lowtime=get_absolute_time();
       if (absolute_time_diff_us(hightime,lowtime) < READPT)
@@ -1123,7 +1135,6 @@ void cwrite(uint8_t nextbit)
         // bodyoff is zero UNLESS we are processing a multi-block data file
         body[(secbits/8)+(bodyoff*blocksize)]=0x00;
         longread=true;
-        mzspinny(1); // Increment the tape counter
       }
       else {
         longread=false;    // Reset for next byte
@@ -1147,14 +1158,11 @@ void cwrite(uint8_t nextbit)
     /* Check to see if we're at the end of the body or 0x04 data block */
     if (secbits==bodybytes*8) {
       if (bsd4file) {
-        mzemustatus[18]=0x24;
         if ((body[0+(bodyoff*blocksize)] == 0xFF) && 
             (body[1+(bodyoff*blocksize)] == 0xFF)) {
           /* We have the end of file marker for type 0x04 */
-          mzemustatus[19]=0x25;
           endofdatafile=true;
         }
-        mzemustatus[20]=0x26;
       }
       /* Need to increment bodyoff if we're not at end of a data file */
       if ((bsd3file||bsd4file)&&(!endofdatafile)) ++bodyoff;
@@ -1167,6 +1175,9 @@ void cwrite(uint8_t nextbit)
 
   /* State 9 - file body checksum */
   if (cwstate==9) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     if (nextbit==0) {
       lowtime=get_absolute_time();
       if (absolute_time_diff_us(hightime,lowtime) < READPT)
@@ -1209,6 +1220,9 @@ void cwrite(uint8_t nextbit)
   /* State 12 - file checksum copy  - CHK_L + 2 pulses */
 
   if (cwstate==10) {
+    // Update tape counter
+    if ((secbits%8)==0)
+      mzspinny(1);
     ++secbits;                 // Increment bits counted
     /* Check that we have received enough 1/0 bits - 2 x number of pulses */
     if (secbits==(L_L+S256_L+bodybytes*8+bodybytes+CHK_L+2)*2) {
@@ -1216,7 +1230,6 @@ void cwrite(uint8_t nextbit)
       // if we are processing a data file and it is multi-block. Note that
       // blocksize and bodybytes are the same for type 0x03 and 0x04 files ...
       if ((bsd3file||bsd4file) && (!endofdatafile)) {
-        mzemustatus[8]=0x20+bodyoff;
         cwstate=7;
       }
       else
@@ -1249,7 +1262,6 @@ void cwrite(uint8_t nextbit)
         secbits=0;
         high=0;
         low=0;
-        mzemustatus[3]=0x90;
       }
       else {
         // Error - quit now
@@ -1257,7 +1269,6 @@ void cwrite(uint8_t nextbit)
         secbits=0;
         high=0;
         low=0;
-        mzemustatus[3]=0x95;
       }
     }
     return;

--- a/cassette.c
+++ b/cassette.c
@@ -84,11 +84,11 @@ void mzspinny(uint8_t state)
   // Increment ignore. If this is >= counterinc then increment spinny.
   // If spinny > TCOUNTERMAX then spinny is reset to zero.
 
-  counterinc = (mzmodel == MZ700) ? 708 : 400;
+  counterinc=(mzmodel==MZ700) ? 708 : 400;
 
-  if ((++ignore) >= counterinc) {
+  if ((++ignore)>=counterinc) {
     ignore=0;
-    if ((++spinny) > TCOUNTERMAX) {
+    if ((++spinny)>TCOUNTERMAX) {
       spinny=0;
     }
   }
@@ -153,9 +153,9 @@ FRESULT mzsavedump(void)
   uramheader[12]= 0x0d;             // <end of name>
 
   // Distinguish between K, A and 700 dump files 
-  if (mzmodel == MZ80K)
+  if (mzmodel==MZ80K)
     dumpfile[6]='K';
-  else if (mzmodel == MZ80A)
+  else if (mzmodel==MZ80A)
     dumpfile[6]='A';
   else
     dumpfile[6]='7';
@@ -230,9 +230,9 @@ FRESULT mzreaddump(void)
   { 'M','Z','D','U','M','P',' ','.','M','Z','F','\0' };
 
   // Distinguish between K, A and 700 dump files 
-  if (mzmodel == MZ80K)
+  if (mzmodel==MZ80K)
     dumpfile[6]='K';
-  else if (mzmodel == MZ80A)
+  else if (mzmodel==MZ80A)
     dumpfile[6]='A';
   else
     dumpfile[6]='7';
@@ -653,7 +653,7 @@ uint8_t cread(void)
       mzspinny(1);
     if (secbits<HDR_L) {
       /* One LONGPULSE is sent before every byte of the header */
-      if (((secbits%8)==0) && (longsent==false)) {
+      if (((secbits%8)==0) && (!longsent)) {
         /* Note - we don't increment secbits here */
         longsent=true;
         return(LONGPULSE);
@@ -661,7 +661,7 @@ uint8_t cread(void)
       longsent=false;
       /* Bytes are sent starting with bit 7 (msb) */
       bitshift=secbits%8;
-      if (((header[secbits++/8]<<bitshift)&0x80) == 0x80) {
+      if (((header[secbits++/8]<<bitshift)&0x80)==0x80) {
         ++chkbits; // Increment the long pulse count for calculating chkh
         return(LONGPULSE);
       }
@@ -687,7 +687,7 @@ uint8_t cread(void)
         // Reset chkbits for the next time a checksum is calculated
         chkbits=0;
       }
-      if (((secbits % 8) == 0) && (longsent == false)) {
+      if (((secbits % 8)==0) && (!longsent)) {
         /* Note - we don't increment secbits here */
         longsent = true;
         return(LONGPULSE);
@@ -696,7 +696,7 @@ uint8_t cread(void)
       longsent = false;
       /* Bytes are sent starting with the MSB */
       bitshift=secbits%8;
-      if (((checksum[secbits++/8]<<bitshift)&0x80) == 0x80) {
+      if (((checksum[secbits++/8]<<bitshift)&0x80)==0x80) {
         return(LONGPULSE);
       }
       return(SHORTPULSE);
@@ -785,7 +785,7 @@ uint8_t cread(void)
         /* in the first two bytes of each block. 0xFF, 0xFF indicates EOF  */
         /* is in that block */
         if (((mzmodel==MZ80K)||(mzmodel==MZ80A)) && bsd3file) {
-          if (body[(secbits/8)+(bodyoff*bodybytes)] == 0xFF) {
+          if (body[(secbits/8)+(bodyoff*bodybytes)]==0xFF) {
             endofdatafile=true;
           }
         }
@@ -794,7 +794,7 @@ uint8_t cread(void)
       longsent=false;
       /* Bytes are sent starting with bit 7 (msb) */
       bitshift=secbits%8;
-      if (((body[(secbits++/8)+(bodyoff*bodybytes)]<<bitshift)&0x80) == 0x80) {
+      if (((body[(secbits++/8)+(bodyoff*bodybytes)]<<bitshift)&0x80)==0x80) {
         ++chkbits; // Increment the long pulse count for calculating chkb
         return(LONGPULSE);
       }
@@ -825,7 +825,7 @@ uint8_t cread(void)
         // Reset chkbits for the next time a checksum is calculated
         chkbits=0;
       }
-      if (((secbits % 8) == 0) && (longsent == false)) {
+      if (((secbits % 8)==0) && (!longsent)) {
         /* Note - we don't increment secbits here */
         longsent = true;
         return(LONGPULSE);
@@ -834,7 +834,7 @@ uint8_t cread(void)
       longsent = false;
       /* Bytes are sent starting with the MSB */
       bitshift=secbits%8;
-      if (((checksum[secbits++/8]<<bitshift)&0x80) == 0x80) {
+      if (((checksum[secbits++/8]<<bitshift)&0x80)==0x80) {
         return(LONGPULSE);
       }
       return(SHORTPULSE);
@@ -873,7 +873,7 @@ uint8_t cread(void)
     }
     if (secbits<L_L+S256_L) {
       ++secbits;
-      if (secbits == L_L+S256_L) {
+      if (secbits==L_L+S256_L) {
         secbits=0;
         crstate=7;
       }
@@ -996,7 +996,7 @@ void cwrite(uint8_t nextbit)
         pulse=0;                 // We have a low (short) pulse
       else 
         pulse=1;                 // We have a high (long) pulse
-      if (((secbits%8)==0) && (longread==false)) {
+      if (((secbits%8)==0)&&(!longread)) {
         // This is the long pulse that preceeds every byte of the header,
         // so we ignore it and blank the next byte of the header ready
         // for the next 8 bits
@@ -1025,7 +1025,7 @@ void cwrite(uint8_t nextbit)
       endofdatafile=false;
       blocksize=((header[19]<<8)&0xFF00)|header[18];
       /* Is this a data file ? Type is 0x03 for MZ-80, 0x04 for MZ-700 */
-      if (((mzmodel==MZ80K) || (mzmodel==MZ80A)) && (header[0]==0x03)) {
+      if (((mzmodel==MZ80K)||(mzmodel==MZ80A))&&(header[0]==0x03)) {
         bsd3file=true;
         // Blocksize is (usually!!) 0x0080 on a MZ-80K (128 bytes), 
         // 0x0100 (256 bytes) on a MZ-80A
@@ -1051,7 +1051,7 @@ void cwrite(uint8_t nextbit)
         pulse=0;                 // We have a low (short) pulse
       else 
         pulse=1;                 // We have a high (long) pulse
-      if (((secbits%8)==0) && (longread==false)) {
+      if (((secbits%8)==0) && (!longread)) {
         // This is the long pulse that preceeds every byte of the checksum,
         // so we ignore it and blank the next byte of the checksum ready
         // for the next 8 bits
@@ -1070,7 +1070,7 @@ void cwrite(uint8_t nextbit)
     /* Check to see if we're at the end of the checksum - this code assumes it's correct(!) and carries on regardless */
     if (secbits==CHK_L) {
       bodybytes=((header[19]<<8)&0xFF00)|header[18]; // Needed for state 8
-      if (bsd3file || bsd4file) bodybytes=blocksize; // Overwrite if data file
+      if (bsd3file||bsd4file) bodybytes=blocksize; // Overwrite if data file
       cwstate=4;
       chkbits=0;
       secbits=0;
@@ -1128,7 +1128,7 @@ void cwrite(uint8_t nextbit)
         pulse=0;                 // We have a low (short) pulse
       else 
         pulse=1;                 // We have a high (long) pulse
-      if (((secbits%8)==0) && (!longread)) {
+      if (((secbits%8)==0)&&(!longread)) {
         // This is the long pulse that preceeds every byte of the body,
         // so we ignore it and blank the next byte of the body ready
         // for the next 8 bits
@@ -1145,7 +1145,7 @@ void cwrite(uint8_t nextbit)
         // If this is a data file of type 0x03, and we've just seen a 0xFF
         // byte, we've seen the end of file marker. Note that the rest of
         // the block needs to be written, but the contents will be invalid.
-        if (((secbits%8)==7) && (bsd3file))
+        if (((secbits%8)==7)&&bsd3file)
           // 0xFF is NOT an EOF marker in type 0x04 data files
           if (bsd3file && (body[(secbits/8)+(bodyoff*blocksize)]==0xFF))
             endofdatafile=true;
@@ -1158,8 +1158,8 @@ void cwrite(uint8_t nextbit)
     /* Check to see if we're at the end of the body or 0x04 data block */
     if (secbits==bodybytes*8) {
       if (bsd4file) {
-        if ((body[0+(bodyoff*blocksize)] == 0xFF) && 
-            (body[1+(bodyoff*blocksize)] == 0xFF)) {
+        if ((body[0+(bodyoff*blocksize)]==0xFF) && 
+            (body[1+(bodyoff*blocksize)]==0xFF)) {
           /* We have the end of file marker for type 0x04 */
           endofdatafile=true;
         }
@@ -1180,11 +1180,11 @@ void cwrite(uint8_t nextbit)
       mzspinny(1);
     if (nextbit==0) {
       lowtime=get_absolute_time();
-      if (absolute_time_diff_us(hightime,lowtime) < READPT)
+      if (absolute_time_diff_us(hightime,lowtime)<READPT)
         pulse=0;                 // We have a low (short) pulse
       else 
         pulse=1;                 // We have a high (long) pulse
-      if (((secbits%8)==0) && (longread==false)) {
+      if (((secbits%8)==0)&&(!longread)) {
         // This is the long pulse that preceeds every byte of the checksum,
         // so we ignore it and blank the next byte of the checksum ready
         // for the next 8 bits
@@ -1243,7 +1243,7 @@ void cwrite(uint8_t nextbit)
   if (cwstate==13) {
     if (nextbit==0) {
       lowtime=get_absolute_time();
-      if (absolute_time_diff_us(hightime,lowtime) < READPT)
+      if (absolute_time_diff_us(hightime,lowtime)<READPT)
         ++low;                   // We have a low (short) pulse
       else
         ++high;                  // We have a high (long) pulse

--- a/cassette.c
+++ b/cassette.c
@@ -25,13 +25,14 @@
                          /* calculation is in the comment below */
 //(L_L+S256_L+HDR_L+(HDR_L/8)+CHK_L+(CHK_L/8)+L_L+WSGAP_L+STM_L+L_L)*2 
 
-/* Used in mzspinny() */
-#define TCOUNTERMAX 999  // Maximum value of tapecounter
+#define TCOUNTERMAX 999  // Maximum value of tapecounter - used in mzspinny()
 uint8_t crstate=0;       // Holds tape state for cread()
 uint8_t cwstate=0;       // Holds tape state for cwrite()
 
 uint8_t header[TAPEHEADERSIZE]; // Tape headers are always 128 bytes
-uint8_t body[TAPEBODYMAXSIZE];  // Maximum storage is 47.5K - 48640 bytes
+uint8_t body[TAPEBODYMAXSIZE];  // Maximum storage is 68K - 69632 bytes
+                                // Needs to be larger than real max tape
+                                // sizes due to memory dump read/write code
 
 static FATFS fs;         // File system pointer for sd card
 
@@ -204,9 +205,6 @@ FRESULT mzsavedump(void)
   // Write 'tape' contents - 8253 state
   f_write(&fp, &mzpit, sizeof(mzpit), &bw);
 
-  // Close the file and return
-  f_close(&fp);
-
   // Write confirmation message to status area
   memset(mzemustatus,0x00,200); // Blank status area
   uint8_t spos=EMULINE1;
@@ -215,6 +213,8 @@ FRESULT mzsavedump(void)
   for (uint8_t i=0; i<32; i++) // Can't use strlen as space is 0x00!
     mzemustatus[spos++]=mzstr[i];
 
+  // Close the file and return
+  f_close(&fp);
   return(FR_OK);
 }
 
@@ -360,6 +360,7 @@ int16_t tapeloader(int16_t n)
   }
   
   // MZ-80K/A/700 tape headers are always 128 bytes
+  memset(header,0x00,TAPEHEADERSIZE);
   f_read(&fp,header,TAPEHEADERSIZE,&bytesread);
   if (bytesread != TAPEHEADERSIZE) {
     f_close(&fp);
@@ -368,12 +369,20 @@ int16_t tapeloader(int16_t n)
 
   // Work out how many bytes to read from the header - stored in
   // locations header[19] and header[18] (msb, lsb)
-  bodybytes=((header[19]<<8)&0xFF00)|header[18];
-  f_read(&fp,body,bodybytes,&bytesread);
-  if (bytesread != bodybytes) {
-    f_close(&fp);
-    return(-1);
-  }
+  //bodybytes=((header[19]<<8)&0xFF00)|header[18];
+  //f_read(&fp,body,bodybytes,&bytesread);
+  //if (bytesread != bodybytes) {
+  //  f_close(&fp);
+  //  return(-1);
+  //}
+
+  // Original method above won't work if the MZ file type is a data file.
+  // (or, at least it wouldn't if we took any notice of the return status!)
+  // Instead, attempt to read the maximum file size TAPEBODYMAXSIZE and 
+  // ignore any error - bytesread will almost certainly always be smaller
+  // than the request. v3.1.0, August 2026.
+  memset(body,0x00,TAPEBODYMAXSIZE);
+  f_read(&fp,body,TAPEBODYMAXSIZE,&bytesread);
 
   // Update the preloaded tape name in the emulator status area. Note
   // this is the name stored in the header, NOT the actual file name on
@@ -408,8 +417,9 @@ int16_t tapeloader(int16_t n)
     mzemustatus[spos++]=mzstr[i];
 
   // Type of tape is stored in the header
-  // 0x01 = machine code, 0x02 = language (BASIC,Pascal etc.), 0x03 = data
-  // 0x04 = zen source, 0x05 = S-BASIC on MZ700, 0x06 = Chalkwell BASIC (MZ80)
+  // 0x01 = Machine code, 0x02 = Language (BASIC,Pascal etc.), 0x03 = MZ-80 data
+  // 0x04 = Zen source (MZ-80) or MZ-700 data, 0x05 = S-BASIC on MZ700 
+  // 0x06 = Chalkwell BASIC (MZ80)
   // 0x20 = memory dump (Pico MZ-80K/A/700 specific)
   switch (header[0]) {
     case 0x01: if (ukrom)
@@ -427,18 +437,28 @@ int16_t tapeloader(int16_t n)
                  mzemustatus[spos++]=mzstr[i];
                break;
     case 0x03: if (ukrom)
-                 ascii2mzdisplay("Data file",mzstr);
+                 ascii2mzdisplay("MZ-80 data file",mzstr);
                else
-                 ascii2mzdisplay("DATA FILE",mzstr);
-               for (uint8_t i=0; i<9; i++)
+                 ascii2mzdisplay("MZ-80 DATA FILE",mzstr);
+               for (uint8_t i=0; i<15; i++)
                  mzemustatus[spos++]=mzstr[i];
                break;
-    case 0x04: if (ukrom)
-                 ascii2mzdisplay("Zen source",mzstr);
-               else
-                 ascii2mzdisplay("ZEN SOURCE",mzstr);
-               for (uint8_t i=0; i<10; i++)
-                 mzemustatus[spos++]=mzstr[i];
+    case 0x04: if (mzmodel==MZ700) {
+                 if (ukrom)
+                   ascii2mzdisplay("MZ-700 data file",mzstr);
+                 else
+                   ascii2mzdisplay("MZ-700 DATA FILE",mzstr);
+                 for (uint8_t i=0; i<16; i++)
+                   mzemustatus[spos++]=mzstr[i];
+               } 
+               else {
+                 if (ukrom)
+                   ascii2mzdisplay("Zen source",mzstr);
+                 else
+                   ascii2mzdisplay("ZEN SOURCE",mzstr);
+                 for (uint8_t i=0; i<10; i++)
+                   mzemustatus[spos++]=mzstr[i];
+               }
                break;
     case 0x05: if (ukrom)
                  ascii2mzdisplay("Sharp S-BASIC",mzstr);
@@ -477,7 +497,7 @@ int16_t tapeloader(int16_t n)
 }
 
 /* Write a new file to sd card 'tape'                             */
-void tapewriter(void)
+void tapewriter(uint16_t bodyoff)
 {
   uint8_t sharpfilelen=0;
   uint8_t sdfilename[22];  // sdfilename needs 1 more char than
@@ -488,6 +508,8 @@ void tapewriter(void)
   uint16_t i;              // Counts file body bytes written to sd card
   FRESULT res;
   FIL fp;
+
+  mzemustatus[10]=0x20+(uint8_t)bodyoff;
 
   // Sharp tape file name is up to 17 characters stored in header[1]
   // to header[17]. If less than 17 characters, name ends with 0x0D
@@ -516,9 +538,10 @@ void tapewriter(void)
   // Write the 128 byte header to the file
   f_write(&fp, header, TAPEHEADERSIZE, &bw);
 
-  // Write the tape body to the file
+  // Write the tape body to the file - note that we need multiples of
+  // this value if we have a data file (size will be bodybytes*(bodyoff+1))
   uint16_t bodybytes=((header[19]<<8)&0xFF00)|header[18];
-  for (i=0;i<bodybytes;i++)
+  for (i=0;i<(bodybytes*(bodyoff+1));i++)
     f_write(&fp, &body[i], 1, &bw);
 
   // Close the file and return
@@ -543,14 +566,13 @@ void reset_tape(void)
   return;
 }
 
-/* Read a MZ-80K/A/700 format tape one bit at a time  */
-/* Pseudo finite state machine implementation         */
-/* If the header and body are read successfully       */
-/* at the first attempt, the read process ends        */
-/* and the second copy is not read. This impl.        */
-/* assumes that the first read is ALWAYS good,        */
-/* as we're using .mzf files rather than a real       */
-/* cassette tape.                                     */
+/* Read a MZ-80K/A/700 format tape one bit at a time.  */
+/* Pseudo finite state machine implementation          */
+/* If the header and body are read successfully at the */
+/* first attempt, the read process ends and the second */
+/* copy is not read. This implementation assumes that  */
+/* the first copy is ALWAYS good, as we're using .mzf  */
+/* files rather than a real cassette tape.             */
 uint8_t cread(void)
 {
                              // Used to calculate the bit to output from tape
@@ -564,6 +586,20 @@ uint8_t cread(void)
   static uint8_t checksum[2];// Stores the calculated checksum
   static uint8_t hilo=0;     // Used for the 1 -> tape bit read -> 0 logic
   static uint32_t secbits;   // Tracks where we are in the current tape section
+
+  /* Below added for data file handling in version 3.1.0 */
+  static bool bsd3file;      // Set true in state 3 if file is a 0x03 data file
+  static bool bsd4file;      // Set true in state 3 if file is a 0x04 data file
+  static bool endofdatafile; // Set false in state 3 - set true when EOF marker
+                             // seen in body processing (state 8) and bsd<x>file
+                             // is true
+  static bool skip101112;    // Used to determine if we need to skip a copy
+                             // of the data block just read - multi-block data
+                             // files only
+  static uint16_t bodyoff=0; // Body array offest - incremented by 1 per block
+                             // if the file is a multi-block data file
+                             // Initialised to zero in state 3
+  
 
   if (cmotor==0) {
     if (crstate==0) {
@@ -665,6 +701,27 @@ uint8_t cread(void)
       }
       return(SHORTPULSE);
     }
+
+    /* Tape body - length is calculated from the values stored by the header */
+    /* in memory locations 0x1103 and 0x1102 from the 20th & 19th values     */
+    /* found in the header - i.e. header[19] (msb) and header[18] (lsb).     */
+    /* Note: This is the blocksize if we have an MZ-80A or MZ-80K tape,      */
+    /* not the total file length */
+    bodybytes=((header[19]<<8)&0xFF00)|header[18];
+    if (((mzmodel==MZ80K)||(mzmodel==MZ80A))&&(header[0]==0x03)) {
+      bsd3file=true;
+      endofdatafile=false;
+      // If we have a multi-block data file we need to skip each body copy
+      skip101112=true;
+    }
+    if ((mzmodel==MZ700)&&(header[0]==0x04)) {
+      bodybytes=258;   // May not be set in the header, so force to 258 bytes.
+      bsd4file=true;
+      endofdatafile=false;
+      // If we have a multi-block data file we need to skip each body copy
+      skip101112=true;
+    }
+
     /* At the end of the checksum */
     /* Note - current assumption is that this is correct */
     /* Reasonable - as this isn't a real cassette tape */
@@ -706,33 +763,51 @@ uint8_t cread(void)
       return(LONGPULSE);
     }
     secbits=0;
-    /* Tape body - length is calculated from the values stored by the header */
-    /* in memory locations 0x1103 and 0x1102 from the 20th & 19th values     */
-    /* found in the header - i.e. header[19] (msb) and header[18] (lsb).     */
-    bodybytes=((header[19]<<8)&0xFF00)|header[18];
+    chkbits=0;
+    longsent=false;
     crstate=8;
+    mzemustatus[36]=0x27;
+    if (!cmotor) cmotor=1;
+    if (!csense) csense=1;
   }
 
   /* Process the tape body - state 8 */
   if (crstate==8) {
+    if (!cmotor) cmotor=1;
+    if (!csense) csense=1;
     if (secbits<(bodybytes*8)) {     // 1 byte = 8 bits to transmit
-      /* One LONGPULSE is sent before every byte of the header */
-      if (((secbits%8)==0) && (longsent==false)) {
+      /* One LONGPULSE is sent before every byte of the body */
+      if (((secbits%8)==0) && (!longsent)) {
         /* Note - we don't increment secbits here */
         longsent=true;
-        mzspinny(1); //Increment tape counter
+        mzspinny(1); // Increment tape counter
+        mzemustatus[19]=0x9a;
+        mzemustatus[20]=0x20+bodyoff;
+        mzemustatus[21]=0x9a;
+        /* If this is an MZ-80A or MZ-80K data file, check if we have 0xFF */
+        if (((mzmodel==MZ80K)||(mzmodel==MZ80A)) && bsd3file) {
+          if (body[(secbits/8)+(bodyoff*bodybytes)] == 0xFF) {
+            endofdatafile=true;
+            skip101112=true;
+            mzemustatus[30]=0x9A;
+          }
+          else {
+            mzemustatus[40+(secbits/8)]=0x20+bodyoff;
+          }
+        }
         return(LONGPULSE);
       }
       longsent=false;
       /* Bytes are sent starting with bit 7 (msb) */
       bitshift=secbits%8;
-      if (((body[secbits++/8]<<bitshift)&0x80) == 0x80) {
+      if (((body[(secbits++/8)+(bodyoff*bodybytes)]<<bitshift)&0x80) == 0x80) {
         ++chkbits; // Increment the long pulse count for calculating chkb
         return(LONGPULSE);
       }
       return(SHORTPULSE);
     }
     /* At the end of the body, move onto checksum state (9) */
+    mzemustatus[38]=0x28;
     secbits=0;
     crstate=9;
   }
@@ -763,20 +838,55 @@ uint8_t cread(void)
       }
       return(SHORTPULSE);
     }
-    /* At the end of the checksum stop */
-    /* Assumes copy of program data is not needed */
+    /* At the end of the checksum stop - unless we have a multi-block */
+    /* data file to read - if so, go back to state 8 until we have read */
+    /* all of it */
+    /* Assumes copy of program / data is never needed as .mzf files used */
     secbits=0;
-    crstate=13; 
+    if ((bsd3file||bsd4file) && (!endofdatafile)) {
+        secbits=0;
+        chkbits=0;
+        longsent=false;
+        bodyoff++;
+        crstate=7;
+    }
+    else {
+      // End of file
+      mzemustatus[39]=0x29;
+      secbits=0;
+      crstate=13; 
+    }
   }
 
   /* States 10,11 and 12 are only needed if the program body has failed */
-  /* to checksum correctly, so are not required for .mzf files */
+  /* to checksum correctly, so are not required for .mzf program files */
+  /* State 10 is used by multi-block data files before returning to state 8 */
+  /* In this case, states 8 and 9 are equivalent to states 11 and 12 */
   /* State 10 - a long pulse followed by 256 short */
   /* State 11 - a copy of the body */
   /* State 12 - a copy of the body checksum */
+  
+  if (crstate==10) {
+    if (secbits<L_L) {
+      ++secbits;
+      return(LONGPULSE);
+    }
+    if (secbits<L_L+S256_L) {
+      ++secbits;
+      return(SHORTPULSE);
+    }
+    secbits=0;
+    chkbits=0;
+    longsent=false;
+    ++bodyoff;
+    crstate=7;
+    memset(mzemustatus,0x00,200);
+    mzemustatus[30]=0x24;
+  }
 
   if (crstate==13) {
   /* At end of body checksum, reset tape state, send final stop bit */
+      mzemustatus[38]=0x9A;
       hilo=0;
       reset_tape();
       return(LONGPULSE);
@@ -808,6 +918,19 @@ void cwrite(uint8_t nextbit)
                              // MUST be a 16 bit unsigned value
   static uint8_t checksum[2];// Stores the calculated checksum
   uint8_t pulse;             // Current header or body pulse: 0=low, 1=high
+
+  /* Below added for data file handling in version 3.1.0 */
+  static bool bsd3file;      // Set true in state 2 if file is a 0x03 data file
+  static bool bsd4file;      // Set true in state 2 if file is a 0x04 data file
+  static bool endofdatafile; // Set false in state 2 - set true when EOF marker
+                             // seen in body processing (state 8) and bsd<x>file
+                             // is true
+  static uint16_t blocksize; // Set to file body size in state 2 if we have 
+                             // a data file of any type (0x03 on MZ-80 or 
+                             // 0x04 on MZ-700), otherwise zero
+  static uint16_t bodyoff;   // Body array offest - incremented by 1 per block
+                             // if the file is a multi-block data file
+                             // Initialised to zero in state 2
   
   if (cwstate==0) {
     /* The first high bit has been received */
@@ -882,11 +1005,35 @@ void cwrite(uint8_t nextbit)
     else {
       hightime=get_absolute_time();
     }
+
     /* Check to see if we're at the end of the header */
     if (secbits==HDR_L) {
       cwstate=3;
       secbits=0;
       longread=false;
+      /* Default the variables used to track data files */
+      bsd3file=false;
+      bsd4file=false;
+      endofdatafile=false;
+      blocksize=0;
+      bodyoff=0;
+      /* Is this a data file ? Type is 0x03 for MZ-80, 0x04 for MZ-700 */
+      if ((mzmodel == MZ80K) || (mzmodel == MZ80A)) {
+        if (header[0]==0x03) {
+          bsd3file=true;
+          blocksize=((header[19]<<8)&0xFF00)|header[18];
+          mzemustatus[0]=0x22;
+          mzemustatus[1]=0x99;
+        }
+      }
+      else if (mzmodel == MZ700) {
+        if (header[0]==0x04) {
+          bsd4file=true;
+          blocksize=((header[19]<<8)&0xFF00)|header[18];
+          mzemustatus[0]=0x22;
+          mzemustatus[1]=0x9A;
+        }
+      }
     }
     return;
   }
@@ -946,6 +1093,18 @@ void cwrite(uint8_t nextbit)
     return;
   }
 
+  /* State 7 - long pulse, short tape gap, short tape mark */
+  /* Only used in emulator for multi-block data files of type 0x03 or 0x04 */
+  if (cwstate==7) {
+    ++secbits;                   // Increment number of bits received
+                                 // (1 pulse = 1 followed by 0 = 2 bits)
+    if (secbits==((L_L+WSGAP_L+STM_L+L_L)*2)) {
+      cwstate=8;
+      secbits=0;
+    }
+    return;
+  }
+
   /* State 8 - file body */
   if (cwstate==8) {
     if (nextbit==0) {
@@ -954,26 +1113,43 @@ void cwrite(uint8_t nextbit)
         pulse=0;                 // We have a low (short) pulse
       else 
         pulse=1;                 // We have a high (long) pulse
-      if (((secbits%8)==0) && (longread==false)) {
+      if (((secbits%8)==0) && (!longread)) {
         // This is the long pulse that preceeds every byte of the body,
         // so we ignore it and blank the next byte of the body ready
         // for the next 8 bits
-        body[secbits/8]=0x00;
+        // bodyoff is zero UNLESS we are processing a multi-block data file
+        body[(secbits/8)+(bodyoff*blocksize)]=0x00;
         longread=true;
-        mzspinny(1); //Increment tape counter
+        mzspinny(1); // Increment the tape counter
       }
       else {
         longread=false;    // Reset for next byte
-        body[secbits/8]=(body[secbits/8]<<1)|pulse; // order is msb first 
-        ++secbits;         // Increment data pulses counted
+                           // pulse order is msb first 
+        body[(secbits/8)+(bodyoff*blocksize)]=
+          (body[(secbits/8)+(bodyoff*blocksize)]<<1)|pulse; 
         chkbits += pulse;  // If pulse was long, increment chkbits count
+        // If this is a data file of type 0x03, and we've just seen a 0xFF
+        // byte, we've seen the end of file marker. Note that the rest of
+        // the block needs to be written, but the contents will be invalid.
+        if (((secbits%8)==7) && (bsd3file))
+          if (body[(secbits/8)+(bodyoff*blocksize)]==0xFF) endofdatafile=true;
+        ++secbits;         // Increment data pulses counted
       }
     }
     else {
       hightime=get_absolute_time();
     }
-    /* Check to see if we're at the end of the body */
+    /* Check to see if we're at the end of the body or 0x04 data block */
     if (secbits==bodybytes*8) {
+      if (bsd4file) {
+        if ((body[0+(bodyoff*blocksize)] == 0xFF) && 
+            (body[1+(bodyoff*blocksize)] == 0xFF)) {
+          /* We have the end of file marker for type 0x04 */
+          endofdatafile=true;
+        }
+      }
+      /* Need to increment bodyoff if we're not at end of a data file */
+      if ((bsd3file||bsd4file)&&(!endofdatafile)) ++bodyoff;
       cwstate=9;
       secbits=0;
       longread=false;
@@ -1028,8 +1204,13 @@ void cwrite(uint8_t nextbit)
     ++secbits;                 // Increment bits counted
     /* Check that we have received enough 1/0 bits - 2 x number of pulses */
     if (secbits==(L_L+S256_L+bodybytes*8+bodybytes+CHK_L+2)*2) {
-      // Assumed all ok - move onto the final state
-      cwstate=13;
+      // Assumed all ok - move onto the final state (13) or back to state 7
+      // if we are processing a data file and it is multi-block. Note that
+      // blocksize and bodybytes are the same for type 0x03 and 0x04 files ...
+      if (((bsd3file)||(bsd4file)) && (!endofdatafile)) 
+        cwstate=7;
+      else
+        cwstate=13;
       secbits=0;
     }
     return;
@@ -1053,11 +1234,12 @@ void cwrite(uint8_t nextbit)
     if (secbits==L_L) { 
       if (high==L_L) {
         // All ok - finish write
-        tapewriter();
+        tapewriter(bodyoff);
         cwstate=0;
         secbits=0;
         high=0;
         low=0;
+        mzemustatus[2]=0x9B;
       }
       else {
         // Error - quit now
@@ -1065,6 +1247,7 @@ void cwrite(uint8_t nextbit)
         secbits=0;
         high=0;
         low=0;
+        mzemustatus[2]=0xAA;
       }
     }
     return;

--- a/keyboard.c
+++ b/keyboard.c
@@ -455,8 +455,8 @@ void mzhidmapkey80k(uint8_t usbk0, uint8_t modifier)
                  ukrom=!ukrom;            // Toggle between UK and JP CGROM
                  memset(mzemustatus,0x00,EMUSSIZE); // Clear status area
                  break;
-      case 0x43: cmotor=1;
-                 csense=1;
+      case 0x43: cmotor= !cmotor;
+                 csense= !csense;
                  break;
       case 0x44: mzreaddump();            //F11 - read memory dump
                  break;

--- a/keyboard.c
+++ b/keyboard.c
@@ -455,7 +455,9 @@ void mzhidmapkey80k(uint8_t usbk0, uint8_t modifier)
                  ukrom=!ukrom;            // Toggle between UK and JP CGROM
                  memset(mzemustatus,0x00,EMUSSIZE); // Clear status area
                  break;
-
+      case 0x43: cmotor=1;
+                 csense=1;
+                 break;
       case 0x44: mzreaddump();            //F11 - read memory dump
                  break;
       case 0x45: mzsavedump();            //F12 - save memory dump

--- a/keyboard.c
+++ b/keyboard.c
@@ -455,8 +455,8 @@ void mzhidmapkey80k(uint8_t usbk0, uint8_t modifier)
                  ukrom=!ukrom;            // Toggle between UK and JP CGROM
                  memset(mzemustatus,0x00,EMUSSIZE); // Clear status area
                  break;
-      case 0x43: cmotor= !cmotor;
-                 csense= !csense;
+      case 0x43: //cmotor= !cmotor;       //F10 - uncomment to experiment
+                 //csense= !csense;       //with motor/sense control on 80K
                  break;
       case 0x44: mzreaddump();            //F11 - read memory dump
                  break;

--- a/picomz.c
+++ b/picomz.c
@@ -437,26 +437,36 @@ int main(void)
 
   // Main emulator loop
   uint8_t delay=0;
+  uint64_t nowtime,exectime;
+  int64_t adjust=0;
   for(;;) {
 
+    exectime=get_absolute_time();
     z80_step(&mzcpu);		  // Execute next z80 opcode
 
-    // Timing adjustments. Depends on Pico model, MZ emulator required and
-    // the carrier board. Changes unpredicatably depending on what's in the
-    // code at the time of compilation.
+    // Timing adjustments 
+    // Depends on Pico model, MZ emulator required and the carrier board
     #ifdef PICO1
-    if ((mzmodel==MZ700) && (++delay == 2)) {
-      busy_wait_us(1);           
-      delay=0;
+    if (mzmodel==MZ700) {
+      nowtime=get_absolute_time();
+      // <<2 equivalent to x4
+      adjust += mzcpu.cyc-((nowtime-exectime)<<2);
+      mzcpu.cyc=0;
+      if (adjust > 1856) {
+        busy_wait_us(64);
+        adjust=0;
+      }
     } 
-    else if ((mzmodel==MZ80K) && (++delay == 3)) {
-      busy_wait_us(2);           
-      delay=0;
+    else if ((mzmodel==MZ80K)||(mzmodel==MZ80A)) {
+      nowtime=get_absolute_time();
+      // <<1 equivalent to x2
+      adjust += mzcpu.cyc-((nowtime-exectime)<<1);
+      mzcpu.cyc=0;
+      if (adjust > 1024) {
+        busy_wait_us(64);
+        adjust=0;
+      }
     } 
-    else if ((mzmodel==MZ80A) && (++delay == 3)) {
-      busy_wait_us(2);           
-      delay=0;
-    }
     #endif
     #ifdef PICO2
     if ((mzmodel==MZ700) && (++delay == 26)) {

--- a/picomz.c
+++ b/picomz.c
@@ -333,6 +333,7 @@ int main(void)
     set_sys_clock_hz(125000000,clocksetok);
   }
   #endif
+
   // Check the clock has been set correctly - signal error if not
   while(!clocksetok) {
     busy_wait_ms(100);
@@ -351,6 +352,26 @@ int main(void)
 
   // Initialise mzemustatus area (bottom 40 scanlines)
   memset(mzemustatus,0x00,EMUSSIZE);
+
+  // Define default pixel colours (MZ-80K and A are monochrome)
+  colourpix[0]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,0,0);        //black
+  colourpix[1]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,0,255);      //blue
+  colourpix[2]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,0,0);      //red
+  colourpix[3]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,0,255);    //magenta
+  colourpix[4]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,255,0);      //green
+  colourpix[5]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,255,255);    //cyan
+  colourpix[6]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,255,0);    //yellow
+  colourpix[7]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,255,255);  //white
+
+  blackpix=colourpix[0];
+  if ((mzmodel == MZ80K) || (mzmodel == MZ700))
+    whitepix=colourpix[7];
+  else
+    /* MZ-80A has green characters */
+    whitepix=colourpix[4];
+
+  // Start VGA output on the second core
+  multicore_launch_core1(vga_main);
 
 #ifdef RC2014VGA
   // Check for I2C capability on RC2014 RP2040 VGA board
@@ -414,26 +435,6 @@ int main(void)
       mzpicoled(toggle);
     }
   }
-
-  // Define default pixel colours (MZ-80K and A are monochrome)
-  colourpix[0]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,0,0);        //black
-  colourpix[1]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,0,255);      //blue
-  colourpix[2]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,0,0);      //red
-  colourpix[3]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,0,255);    //magenta
-  colourpix[4]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,255,0);      //green
-  colourpix[5]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(0,255,255);    //cyan
-  colourpix[6]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,255,0);    //yellow
-  colourpix[7]=PICO_SCANVIDEO_PIXEL_FROM_RGB8(255,255,255);  //white
-
-  blackpix=colourpix[0];
-  if ((mzmodel == MZ80K) || (mzmodel == MZ700))
-    whitepix=colourpix[7];
-  else
-    /* MZ-80A has green characters */
-    whitepix=colourpix[4];
-
-  // Start VGA output on the second core
-  multicore_launch_core1(vga_main);
 
   // Main emulator loop
   uint8_t delay=0;

--- a/picomz.c
+++ b/picomz.c
@@ -1,5 +1,5 @@
 /* MZ-80K, MZ-80A & MZ-700 emulator - main program */
-/* Tim Holyoake, August 2024 - August 2026         */
+/*     Tim Holyoake, August 2024 - August 2026     */
 
 #include "picomz.h"
 
@@ -21,7 +21,7 @@ volatile z80*  unusedz;
 uint8_t mzmodel;                // MZ model type - default is MZ-80K
                                 // Button A at boot = MZ-80A
                                 // Button B at boot = MZ-700
-bool ukrom = true;              // Default is UK CGROM (no JP CGROM for MZ-80A)
+bool ukrom=true;                // Default is UK CGROM (no JP CGROM for MZ-80A)
 
                                 // Keyboard matrix mapping
                                 // All 0xFF means no key to process
@@ -221,11 +221,11 @@ uint8_t mem_read(void* unusedv, uint16_t addr)
       return(addr&0xFF);
     }
 
-  }
+    /* MZ-80A user socket ROM - return 0xC7 if not present */
+    if (addr == 0xE800) {
+      return(0xC7);
+    }
 
-  /* MZ-80A user socket ROM - return 0xC7 if not present */
-  if ((addr == 0xE800) && (mzmodel == MZ80A)) {
-    return(0xC7);
   }
 
   /* All other unused addresses */
@@ -271,14 +271,16 @@ void sio_write(z80* unusedz, uint8_t addr, uint8_t val)
       bank12klck=false;
   }
 
-  /* SIO not used by MZ-80K/A */
+  // SIO write not used by MZ-80K/A as standard, 
+  // but some peripherals not yet emulated may do.
   return;
 }
 
 /* SIO read from device */
 uint8_t sio_read(z80* unusedz, uint8_t addr)
 {
-  /* SIO not read by MZ-80K/A/700, so should never get here */
+  // SIO read not used by MZ-80K/A/700 as standard, 
+  // but some peripherals not yet emulated may do.
   return(0);
 }
 
@@ -298,15 +300,19 @@ int main(void)
   gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
 
   // If button A on the Pico's carrier board is pressed, run the emulator 
-  // as a MZ-80A. Button B = MZ-700, no button = MZ-80K.
+  // as a MZ-80A. Button B/C = MZ-700, no button = MZ-80K.
 
   gpio_init(0);  // Button A
   gpio_init(6);  // Button B
+  gpio_init(11); // Button C - does the same as button B but may be easier to
+                 // press on some PicoMZ carrier boards
   gpio_set_dir(0,GPIO_IN);
   gpio_set_dir(6,GPIO_IN);
+  gpio_set_dir(11,GPIO_IN);
   gpio_pull_down(0);
   gpio_pull_down(6);
-  if (gpio_get(6))
+  gpio_pull_down(11);
+  if (gpio_get(6)||gpio_get(11))
     mzmodel=MZ700;
   else if (gpio_get(0))
     mzmodel=MZ80A;
@@ -334,7 +340,7 @@ int main(void)
   }
   #endif
 
-  // Check the clock has been set correctly - signal error if not
+  // Check the clock has been set correctly - endlessly signal an error if not
   while(!clocksetok) {
     busy_wait_ms(100);
     toggle=!toggle;
@@ -370,7 +376,8 @@ int main(void)
     /* MZ-80A has green characters */
     whitepix=colourpix[4];
 
-  // Start VGA output on the second core
+  // Start VGA output on the second core - takes a while, so do it as early
+  // as possible
   multicore_launch_core1(vga_main);
 
 #ifdef RC2014VGA
@@ -437,7 +444,6 @@ int main(void)
   }
 
   // Main emulator loop
-  uint8_t delay=0;
   uint64_t nowtime,exectime;
   int64_t adjust=0;
   for(;;) {
@@ -445,12 +451,10 @@ int main(void)
     exectime=get_absolute_time();
     z80_step(&mzcpu);		  // Execute next z80 opcode
 
-    // Timing adjustments 
-    // Depends on Pico model, MZ emulator required and the carrier board
+    // Timing adjustments depend on Pico platform and MZ emulator required
     #ifdef PICO1
     if (mzmodel==MZ700) {
       nowtime=get_absolute_time();
-      // <<2 equivalent to x4
       adjust += mzcpu.cyc-((nowtime-exectime)<<2);
       mzcpu.cyc=0;
       if (adjust > 1856) {
@@ -460,7 +464,6 @@ int main(void)
     } 
     else if ((mzmodel==MZ80K)||(mzmodel==MZ80A)) {
       nowtime=get_absolute_time();
-      // <<1 equivalent to x2
       adjust += mzcpu.cyc-((nowtime-exectime)<<1);
       mzcpu.cyc=0;
       if (adjust > 1024) {
@@ -470,18 +473,24 @@ int main(void)
     } 
     #endif
     #ifdef PICO2
-    if ((mzmodel==MZ700) && (++delay == 26)) {
-      busy_wait_us(1);           
-      delay=0;
+    if (mzmodel==MZ700) {
+      nowtime=get_absolute_time();
+      adjust += mzcpu.cyc-((nowtime-exectime)<<2);
+      mzcpu.cyc=0;
+      if (adjust > 1856) {
+        busy_wait_us(64);
+        adjust=0;
+      }
     } 
-    else if ((mzmodel==MZ80K) && (++delay == 2)) {
-      busy_wait_us(3);           
-      delay=0;
-    }
-    else if ((mzmodel==MZ80A) && (++delay == 3)) {
-      busy_wait_us(4);           
-      delay=0;
-    }
+    else if ((mzmodel==MZ80K)||(mzmodel==MZ80A)) {
+      nowtime=get_absolute_time();
+      adjust += mzcpu.cyc-((nowtime-exectime)<<1);
+      mzcpu.cyc=0;
+      if (adjust > 1024) {
+        busy_wait_us(64);
+        adjust=0;
+      }
+    } 
     #endif
 
     tuh_task();                   // Check for new keyboard events

--- a/picomz.h
+++ b/picomz.h
@@ -176,7 +176,8 @@
 
 /* Tape header and maximum body sizes in bytes */
 #define TAPEHEADERSIZE    128 // 128 bytes
-#define TAPEBODYMAXSIZE 49152 // 48 Kbytes
+#define TAPEBODYMAXSIZE 69632 // 68 Kbytes - needs to be big for memory dump
+                              // files
 
 /* Holds global variables relating to the 8253 PIT */
 typedef struct pit8253 {  


### PR DESCRIPTION
Resolves #64 and #82 (but not for Knight's FORTRAN as the files do not conform to BSD types 0x03 or 0x04 - they claim to be of type 0x04 on all platforms, but are not MZ-700 BSD type 4. Will open a new issue for this specific language / compiler).